### PR TITLE
feat: take several base load series in gt

### DIFF
--- a/client/baseloads.go
+++ b/client/baseloads.go
@@ -1,0 +1,34 @@
+package client
+
+import "encoding/json"
+
+// BaseLoads is the household demand of the request. The API takes either a single series or one
+// series per base load, both decode into the summed series the CLI works with.
+type BaseLoads []float32
+
+func (b *BaseLoads) UnmarshalJSON(data []byte) error {
+	var single []float32
+	if err := json.Unmarshal(data, &single); err == nil {
+		*b = single
+		return nil
+	}
+
+	var loads [][]float32
+	if err := json.Unmarshal(data, &loads); err != nil {
+		return err
+	}
+
+	var sum []float32
+	for _, load := range loads {
+		for i, v := range load {
+			if i == len(sum) {
+				sum = append(sum, 0)
+			}
+			sum[i] += v
+		}
+	}
+
+	*b = sum
+
+	return nil
+}

--- a/client/baseloads_test.go
+++ b/client/baseloads_test.go
@@ -1,0 +1,18 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBaseLoadsUnmarshal(t *testing.T) {
+	for _, tc := range []string{`[400,600]`, `[[400,600]]`, `[[100,200],[300,400]]`} {
+		var loads BaseLoads
+		if err := json.Unmarshal([]byte(tc), &loads); err != nil {
+			t.Fatalf("%s: %v", tc, err)
+		}
+		if len(loads) != 2 || loads[0] != 400 || loads[1] != 600 {
+			t.Errorf("%s: got %v", tc, loads)
+		}
+	}
+}

--- a/client/client.gen.go
+++ b/client/client.gen.go
@@ -244,11 +244,8 @@ type TimeSeries struct {
 	// Ft Forecasted energy generation (e.g., solar PV) at each time step (Wh)
 	Ft []float32 `json:"ft"`
 
-	// Gt Household energy demand at each time step (Wh)
-	Gt []float32 `json:"gt"`
-
-	// GtAdd Additional household energy demand time series (Wh), added to gt before optimizing
-	GtAdd [][]float32 `json:"gt_add,omitempty"`
+	// Gt Household energy demand at each time step (Wh), either a single series or one series per base load, which are summed up
+	Gt BaseLoads `json:"gt"`
 
 	// PE Grid export remuneration per Wh at each time step (currency units/Wh)
 	PE []float32 `json:"p_E"`

--- a/client/client.gen.go
+++ b/client/client.gen.go
@@ -247,6 +247,9 @@ type TimeSeries struct {
 	// Gt Household energy demand at each time step (Wh)
 	Gt []float32 `json:"gt"`
 
+	// GtAdd Additional household energy demand time series (Wh), added to gt before optimizing
+	GtAdd [][]float32 `json:"gt_add,omitempty"`
+
 	// PE Grid export remuneration per Wh at each time step (currency units/Wh)
 	PE []float32 `json:"p_E"`
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -289,21 +289,20 @@ components:
           description: Duration in seconds for each time step (s)
           example: [3600, 3600, 3600, 3600, 3600, 3600]
         gt:
-          type: array
-          items:
-            type: number
-            minimum: 0
-          description: Household energy demand at each time step (Wh)
+          x-go-type: BaseLoads
+          oneOf:
+            - type: array
+              items:
+                type: number
+                minimum: 0
+            - type: array
+              items:
+                type: array
+                items:
+                  type: number
+                  minimum: 0
+          description: Household energy demand at each time step (Wh), either a single series or one series per base load, which are summed up
           example: [3000, 4000, 5000, 4500, 3500, 3000]
-        gt_add:
-          type: array
-          items:
-            type: array
-            items:
-              type: number
-              minimum: 0
-          description: Additional household energy demand time series (Wh), added to gt before optimizing
-          example: [[500, 500, 500, 500, 500, 500]]
         ft:
           type: array
           items:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -295,6 +295,15 @@ components:
             minimum: 0
           description: Household energy demand at each time step (Wh)
           example: [3000, 4000, 5000, 4500, 3500, 3000]
+        gt_add:
+          type: array
+          items:
+            type: array
+            items:
+              type: number
+              minimum: 0
+          description: Additional household energy demand time series (Wh), added to gt before optimizing
+          example: [[500, 500, 500, 500, 500, 500]]
         ft:
           type: array
           items:

--- a/src/optimizer/app.py
+++ b/src/optimizer/app.py
@@ -119,10 +119,16 @@ battery_config_model = api.model('BatteryConfig', {
     'c_priority': fields.Integer(required=False, description='Charging and discharging priority compared to other batteries. 2 = highest priority.')
 })
 
+
+class AnySchema(fields.Raw):
+    """Field without a type constraint, gt takes a number or a nested series per entry."""
+    __schema_type__ = None
+
+
 time_series_model = api.model('TimeSeries', {
     'dt': fields.List(fields.Float, required=True, description='duration in seconds for each time step (s)'),
-    'gt': fields.List(fields.Float, required=True, description='Required energy for home consumption at each time step (Wh)'),
-    'gt_add': fields.List(fields.List(fields.Float), required=False, description='Additional home consumption time series (Wh), added to gt before optimizing'),
+    'gt': fields.List(AnySchema, required=True,
+                      description='Required energy for home consumption at each time step (Wh), either one series or a list of series that are summed up'),
     'ft': fields.List(fields.Float, required=True, description='Forecasted solar generation at each time step (Wh)'),
     'p_N': fields.List(fields.Float, required=True, description='Price per Wh taken from grid at each time step'),
     'p_E': fields.List(fields.Float, required=True, description='Remuneration per Wh fed into grid at each time step'),
@@ -212,12 +218,15 @@ class OptimizeCharging(Resource):
 
             # Parse time series data
             ts_data = data['time_series']
-            gt_add = ts_data.get('gt_add') or []
+
+            # gt carries either a single consumption series or one series per base load, the
+            # latter are summed up. anything but a list of lists stays the single series case
+            gt = ts_data['gt']
+            base_loads = gt if gt and all(isinstance(load, list) for load in gt) else [gt]
 
             # Validate time series lengths
-            lengths = [len(ts_data['gt']), len(ts_data['ft']),
-                       len(ts_data['p_N']), len(ts_data['p_E']),
-                       *(len(gt) for gt in gt_add)]
+            lengths = [len(ts_data['ft']), len(ts_data['p_N']), len(ts_data['p_E']),
+                       *(len(load) for load in base_loads)]
 
             # Validate p_demand if provided
             for bat in batteries:
@@ -234,7 +243,7 @@ class OptimizeCharging(Resource):
 
             time_series = TimeSeriesData(
                 dt=ts_data['dt'],
-                gt=[sum(step) for step in zip(ts_data['gt'], *gt_add)] if gt_add else ts_data['gt'],
+                gt=[sum(step) for step in zip(*base_loads)],
                 ft=ts_data['ft'],
                 p_N=ts_data['p_N'],
                 p_E=ts_data['p_E'],

--- a/src/optimizer/app.py
+++ b/src/optimizer/app.py
@@ -122,6 +122,7 @@ battery_config_model = api.model('BatteryConfig', {
 time_series_model = api.model('TimeSeries', {
     'dt': fields.List(fields.Float, required=True, description='duration in seconds for each time step (s)'),
     'gt': fields.List(fields.Float, required=True, description='Required energy for home consumption at each time step (Wh)'),
+    'gt_add': fields.List(fields.List(fields.Float), required=False, description='Additional home consumption time series (Wh), added to gt before optimizing'),
     'ft': fields.List(fields.Float, required=True, description='Forecasted solar generation at each time step (Wh)'),
     'p_N': fields.List(fields.Float, required=True, description='Price per Wh taken from grid at each time step'),
     'p_E': fields.List(fields.Float, required=True, description='Remuneration per Wh fed into grid at each time step'),
@@ -210,17 +211,13 @@ class OptimizeCharging(Resource):
                 ))
 
             # Parse time series data
-            time_series = TimeSeriesData(
-                dt=data['time_series']['dt'],
-                gt=data['time_series']['gt'],
-                ft=data['time_series']['ft'],
-                p_N=data['time_series']['p_N'],
-                p_E=data['time_series']['p_E'],
-            )
+            ts_data = data['time_series']
+            gt_add = ts_data.get('gt_add') or []
 
             # Validate time series lengths
-            lengths = [len(time_series.gt), len(time_series.ft),
-                       len(time_series.p_N), len(time_series.p_E)]
+            lengths = [len(ts_data['gt']), len(ts_data['ft']),
+                       len(ts_data['p_N']), len(ts_data['p_E']),
+                       *(len(gt) for gt in gt_add)]
 
             # Validate p_demand if provided
             for bat in batteries:
@@ -234,6 +231,14 @@ class OptimizeCharging(Resource):
 
             if len(set(lengths)) > 1:
                 api.abort(400, "All time series must have the same length")
+
+            time_series = TimeSeriesData(
+                dt=ts_data['dt'],
+                gt=[sum(step) for step in zip(ts_data['gt'], *gt_add)] if gt_add else ts_data['gt'],
+                ft=ts_data['ft'],
+                p_N=ts_data['p_N'],
+                p_E=ts_data['p_E'],
+            )
 
         except Exception as e:
             api.abort(400, f"Invalid data format: {str(e)}")

--- a/tests/test_gt_add.py
+++ b/tests/test_gt_add.py
@@ -1,0 +1,29 @@
+from optimizer.app import app
+
+
+def request_with(time_series):
+    return {
+        "batteries": [{
+            "s_min": 0, "s_max": 10000, "s_initial": 5000,
+            "c_min": 0, "c_max": 5000, "d_max": 5000, "p_a": 0.1,
+        }],
+        "time_series": {"dt": [3600, 3600], "ft": [0, 0], "p_N": [0.3, 0.3], "p_E": [0.1, 0.1], **time_series},
+    }
+
+
+def test_additional_base_loads_are_summed_into_gt():
+    client = app.test_client()
+
+    split = client.post("/optimize/charge-schedule", json=request_with({"gt": [400, 500], "gt_add": [[100, 200], [500, 300]]}))
+    summed = client.post("/optimize/charge-schedule", json=request_with({"gt": [1000, 1000]}))
+
+    assert split.status_code == 200, split.json
+    assert split.json == summed.json
+
+
+def test_additional_base_load_of_different_length_is_rejected():
+    client = app.test_client()
+
+    response = client.post("/optimize/charge-schedule", json=request_with({"gt": [1000, 1000], "gt_add": [[100]]}))
+
+    assert response.status_code == 400, response.json

--- a/tests/test_multiple_base_loads.py
+++ b/tests/test_multiple_base_loads.py
@@ -11,19 +11,28 @@ def request_with(time_series):
     }
 
 
-def test_additional_base_loads_are_summed_into_gt():
+def test_base_loads_are_summed_into_gt():
     client = app.test_client()
 
-    split = client.post("/optimize/charge-schedule", json=request_with({"gt": [400, 500], "gt_add": [[100, 200], [500, 300]]}))
+    split = client.post("/optimize/charge-schedule", json=request_with({"gt": [[400, 500], [100, 200], [500, 300]]}))
     summed = client.post("/optimize/charge-schedule", json=request_with({"gt": [1000, 1000]}))
 
     assert split.status_code == 200, split.json
+    assert summed.status_code == 200, summed.json
     assert split.json == summed.json
 
 
-def test_additional_base_load_of_different_length_is_rejected():
+def test_a_single_base_load_may_be_nested():
     client = app.test_client()
 
-    response = client.post("/optimize/charge-schedule", json=request_with({"gt": [1000, 1000], "gt_add": [[100]]}))
+    response = client.post("/optimize/charge-schedule", json=request_with({"gt": [[1000, 1000]]}))
+
+    assert response.status_code == 200, response.json
+
+
+def test_base_load_of_different_length_is_rejected():
+    client = app.test_client()
+
+    response = client.post("/optimize/charge-schedule", json=request_with({"gt": [[1000, 1000], [100]]}))
 
     assert response.status_code == 400, response.json


### PR DESCRIPTION
Callers with more than one base load source currently have to sum the series themselves. `gt` now takes either a single consumption series, exactly as before, or one series per base load, which the API sums up before building the model.

- flat `gt` requests are unchanged, no new key and no migration
- every series must have the same length as the rest of the time series, otherwise the request is rejected
- the model itself is untouched, the sum happens during request parsing
- the Go client decodes both shapes into the summed series

🤖 Generated with [Claude Code](https://claude.com/claude-code)